### PR TITLE
Added test coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 /yarn-error.log
 
 .byebug_history
+
+coverage/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+services:
+  - postgresql
+
+before_script:
+  - psql -c 'create database pgapp_test;' -U postgres

--- a/Gemfile
+++ b/Gemfile
@@ -44,5 +44,9 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
 end
 
+group :test do
+  gem 'simplecov', require: false
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
     concurrent-ruby (1.0.5)
     crass (1.0.3)
     diff-lcs (1.3)
+    docile (1.3.0)
     erubi (1.7.1)
     execjs (2.7.0)
     ffi (1.9.23)
@@ -67,6 +68,7 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    json (2.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -150,6 +152,11 @@ GEM
     selenium-webdriver (3.11.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -190,6 +197,7 @@ DEPENDENCIES
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
   selenium-webdriver
+  simplecov
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,5 @@
 <% @posts.reverse.each do |post| %>
-  <p><%= post.message %> <br>Post created on <%= post.created_at.strftime("%m/%d/%Y %H:%M") %></p>
+  <p><%= post.message %> <br> <%= time_ago_in_words(post.created_at) + ' ago'%></p> 
 <% end %>
 
 <%= link_to new_post_path do %>

--- a/spec/features/user_can_submit_posts_spec.rb
+++ b/spec/features/user_can_submit_posts_spec.rb
@@ -14,6 +14,6 @@ RSpec.feature "Timeline", type: :feature do
     click_link "New post"
     fill_in "Message", with: "Hello, world!"
     click_button "Submit"
-    expect(page).to have_content(Time.now.strftime("%m/%d/%Y %H:%M"))
+    expect(page).to have_content("Hello, world! less than a minute ago")
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,15 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'simplecov'
+SimpleCov.start 'rails' do
+  add_filter '/bin/'
+  add_filter '/db/'
+  add_filter '/spec/' # for rspec
+  add_filter '/test/' # for minitest
+end
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
This merge: 
* Adds simplecov to report on test coverage when running RSpec
* Adds Travis.yml to allow Travis to configure the database for testing
* Reworks the post timestamp to use 'time ago' rather than a set time, because Travis is an idiot and would seemingly test the timestamp across two different timezones and then get upset when it was an hour out.

Travis now passes successfully.